### PR TITLE
Correct forecast comparison in loss_functions

### DIFF
--- a/nbs/08_loss_functions.ipynb
+++ b/nbs/08_loss_functions.ipynb
@@ -122,7 +122,7 @@
     "    start = data[data.Date == forecast_start].index[0] + h\n",
     "    end = data[data.Date == forecast_end].index[0] + h + 1\n",
     "\n",
-    "    print(str(h+1) + '-Step Ahead MSE: ' + str(MSE(Y[start:end], forecast[:,h-1]).round(2)))"
+    "    print(str(h+1) + '-Step Ahead MSE: ' + str(MSE(Y[start:end], forecast[:,h]).round(2)))"
    ]
   },
   {
@@ -177,7 +177,7 @@
     "    start = data[data.Date == forecast_start].index[0] + h\n",
     "    end = data[data.Date == forecast_end].index[0] + h + 1\n",
     "\n",
-    "    print(str(h+1) + '-Step Ahead MAD: ' + str(MAD(Y[start:end], forecast[:,h-1]).round(2)))"
+    "    print(str(h+1) + '-Step Ahead MAD: ' + str(MAD(Y[start:end], forecast[:,h]).round(2)))"
    ]
   },
   {
@@ -231,7 +231,7 @@
     "    start = data[data.Date == forecast_start].index[0] + h\n",
     "    end = data[data.Date == forecast_end].index[0] + h + 1\n",
     "\n",
-    "    print(str(h+1) + '-Step Ahead MAPE: ' + str(MAPE(Y[start:end], forecast[:,h-1]).round(2)) + \"%\")"
+    "    print(str(h+1) + '-Step Ahead MAPE: ' + str(MAPE(Y[start:end], forecast[:,h]).round(2)) + \"%\")"
    ]
   },
   {


### PR DESCRIPTION
Right now in the docs, it seems like the wrong slice of the forecasts is being compared to the data.  For example, the first run of the loop will compare the data from forecast_start to forecast_end with the 4-step-ahead forecasts, not the 1-step-ahead.

The corresponding numbers that result would thus need to be updated as well.